### PR TITLE
Giving the loader parameter to the yaml.FullLoader

### DIFF
--- a/fontawesome/generate.py
+++ b/fontawesome/generate.py
@@ -15,7 +15,7 @@ INDENT = ' ' * 2
 
 
 def main(uri, version, include_aliases):
-    icons_dict = yaml.load(requests.get(uri).text)
+    icons_dict = yaml.load(requests.get(uri).text, yaml.FullLoader)
 
     out = sys.stdout
 


### PR DESCRIPTION
#8
When the generate.py file is run, it gives this error:
> TypeError: load() missing 1 required positional argument: 'Loader'

I passed a `FullLoader` loader to this parameter.
Before:
` icons_dict = yaml.load(requests.get(uri).text)`
After:
`icons_dict = yaml.load(requests.get(uri).text, yaml.FullLoader)`